### PR TITLE
refactor(Transactinal 설정 및 N+1 쿼리 문제 해결):

### DIFF
--- a/src/main/java/com/kimje/chat/chats/dto/ChatResponseDTO.java
+++ b/src/main/java/com/kimje/chat/chats/dto/ChatResponseDTO.java
@@ -1,13 +1,9 @@
 package com.kimje.chat.chats.dto;
 
 import java.time.LocalDateTime;
-import java.util.List;
-
 import com.kimje.chat.chats.entity.Chat;
 import com.kimje.chat.chats.enums.ChatRole;
 import com.kimje.chat.chats.enums.ChatTopic;
-import com.kimje.chat.user.dto.UserResponseDTO;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/kimje/chat/chats/repository/MessageRepository.java
+++ b/src/main/java/com/kimje/chat/chats/repository/MessageRepository.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.kimje.chat.chats.entity.Chat;
 import com.kimje.chat.chats.entity.Message;
@@ -12,9 +14,12 @@ import com.kimje.chat.chats.entity.Message;
 public interface MessageRepository extends JpaRepository<Message,Long>{
 
 
-	List<Message> findByChatIdAndCreatedAtAfter(Chat chat,LocalDateTime joinUser);
 
-	List<Message> findByChatId_IdAndCreatedAtAfter(Long chatId, LocalDateTime joinedAt);
+	@Query("SELECT DISTINCT m FROM Message m LEFT JOIN FETCH m.likes WHERE m.chatId.id = :chatId AND m.createdAt > :joinedAt")
+	List<Message> findMessagesWithLikes(
+		@Param("chatId") Long chatId,
+		@Param("joinedAt") LocalDateTime joinedAt
+	);
 
 	Optional<Message> findByChatIdAndId(Chat chatId, long id);
 }

--- a/src/main/java/com/kimje/chat/chats/service/ChatCommandService.java
+++ b/src/main/java/com/kimje/chat/chats/service/ChatCommandService.java
@@ -1,7 +1,6 @@
 package com.kimje.chat.chats.service;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
+
 
 import com.kimje.chat.chats.dto.ChatRequestDTO;
 import com.kimje.chat.chats.dto.ChatResponseDTO;
@@ -19,7 +18,6 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/kimje/chat/chats/service/ChatQueryService.java
+++ b/src/main/java/com/kimje/chat/chats/service/ChatQueryService.java
@@ -21,24 +21,25 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ChatQueryService {
 
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatUserRepository chatUserRepository;
 
-	@Transactional(readOnly = true)
+
 	public PageResponse<ChatResponseDTO.ChatInfo> getChats(Pageable pageable) {
 		Page<ChatResponseDTO.ChatInfo> chats = chatRoomRepository.getChats(pageable);
 		PageResponse<ChatResponseDTO.ChatInfo> pageResponse = PageResponse.from(chats);
 		return pageResponse;
 	}
-	@Transactional(readOnly = true)
+
 	public PageResponse<ChatResponseDTO.ChatInfo> getHotChats(Pageable pageable) {
 		Page<ChatResponseDTO.ChatInfo> hotChats = chatRoomRepository.findHotChats(pageable);
 		PageResponse<ChatResponseDTO.ChatInfo> pageResponse = PageResponse.from(hotChats);
 		return pageResponse;
 	}
-	@Transactional(readOnly = true)
+
 	public PageResponse<ChatResponseDTO.ChatInfo> getMyChats(AuthUser authUser ,Pageable pageable) {
 
 		Page<ChatResponseDTO.ChatInfo> myChats = chatUserRepository.findMyChatsWithCount(authUser.getUserId(), pageable);

--- a/src/main/java/com/kimje/chat/chats/service/message/MessageCommandService.java
+++ b/src/main/java/com/kimje/chat/chats/service/message/MessageCommandService.java
@@ -1,13 +1,8 @@
 package com.kimje.chat.chats.service.message;
-
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import com.kimje.chat.chats.dto.MessageRequestDTO;
-import com.kimje.chat.chats.dto.MessageResponseDTO;
+import org.springframework.transaction.annotation.Transactional;
 import com.kimje.chat.chats.entity.Chat;
 import com.kimje.chat.chats.entity.Message;
 import com.kimje.chat.chats.entity.MessageLike;
@@ -16,18 +11,15 @@ import com.kimje.chat.chats.repository.ChatRoomRepository;
 import com.kimje.chat.chats.repository.ChatUserRepository;
 import com.kimje.chat.chats.repository.MessageLikeRepository;
 import com.kimje.chat.chats.repository.MessageRepository;
-import com.kimje.chat.global.security.OAuth2.AuthUser;
 import com.kimje.chat.user.entity.User;
 import com.kimje.chat.user.repository.UserRepository;
-
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MessageCommandService {
 
 	private final MessageRepository messageRepository;

--- a/src/main/java/com/kimje/chat/chats/service/message/MessageQueryService.java
+++ b/src/main/java/com/kimje/chat/chats/service/message/MessageQueryService.java
@@ -1,7 +1,6 @@
 package com.kimje.chat.chats.service.message;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -20,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MessageQueryService {
 
 	private final ChatUserRepository chatUserRepository;
@@ -33,7 +33,7 @@ public class MessageQueryService {
 			.orElseThrow(() -> new IllegalStateException("채팅방에 참여한 이력이 없습니다."));
 
 		LocalDateTime joinedAt = chatUser.getJoinedAt();
-		List<Message> messages = messageRepository.findByChatId_IdAndCreatedAtAfter(chatId, joinedAt);
+		List<Message> messages = messageRepository.findMessagesWithLikes(chatId, joinedAt);
 
 		Set<Long> likedMessageIds = messageLikeRepository.findLikedMessageIdsByUserIdAndChatIdAfter(
 				authUser.getUserId(), chatId, joinedAt


### PR DESCRIPTION
- 읽기 QueryService 에 readonly =  true 설정
- 쓰기 CommandService 에 Transactinal 설정
- 메시지 목록 반환 메서드 N+1 쿼리 문제 : 기존에 불러왔던 메시지들을 반복문을 돌며 .size() 로 인해 메시지마다 쿼리가 나가던 문제를 fetch join으로 해결